### PR TITLE
Baselines: add results for embeddings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,4 +180,5 @@ results/classify/pca_results/data/*
 
 # data folder for now 
 datasets_complete/**/*.parquet
+datasets_complete/**/*.npy
 !datasets_complete/README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ xgboost==2.0.3
 ipykernel==6.29.3
 evaluate==0.4.2
 great_tables==0.10.0
+sentence-transformers==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ accelerate==0.26.1
 transformers==4.36.2
 torch==2.1.2
 einops==0.6.1
-huggingface_hub==0.20.2
+huggingface_hub==0.26.1
 xformers==0.0.23.post1
 scikit-learn==1.3.1
 seaborn==0.13.0

--- a/results/classify/clf_results/clf_reports/dailydialog_temp1/all_models_embeddings_all_features.txt
+++ b/results/classify/clf_results/clf_reports/dailydialog_temp1/all_models_embeddings_all_features.txt
@@ -1,0 +1,14 @@
+Results from model run at 2024-10-28 16:29:29.159405
+Original dataset: dailydialog, temperature: nan
+Random state: 129
+              precision    recall  f1-score   support
+
+           0       0.93      0.94      0.94      3000
+           1       0.75      0.72      0.74       750
+
+    accuracy                           0.90      3750
+   macro avg       0.84      0.83      0.84      3750
+weighted avg       0.90      0.90      0.90      3750
+
+Model(s) compared with human:['beluga7b', 'llama2_chat13b', 'llama2_chat7b', 'mistral7b']
+Features: ['embeddings', 'dims: 4096']

--- a/results/classify/clf_results/clf_reports/dailydialog_temp1/all_results.html
+++ b/results/classify/clf_results/clf_reports/dailydialog_temp1/all_results.html
@@ -4,51 +4,51 @@
 <meta charset="utf-8"/>
 </head>
 <body>
-<div id="pxnaolhmin" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="bkcduztxsf" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 <style>
-#pxnaolhmin table {
+#bkcduztxsf table {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
 
-#pxnaolhmin thead, tbody, tfoot, tr, td, th { border-style: none; }
+#bkcduztxsf thead, tbody, tfoot, tr, td, th { border-style: none; }
  tr { background-color: transparent; }
-#pxnaolhmin p { margin: 0; padding: 0; }
- #pxnaolhmin .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
- #pxnaolhmin .gt_caption { padding-top: 4px; padding-bottom: 4px; }
- #pxnaolhmin .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
- #pxnaolhmin .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
- #pxnaolhmin .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #pxnaolhmin .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #pxnaolhmin .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #pxnaolhmin .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
- #pxnaolhmin .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
- #pxnaolhmin .gt_column_spanner_outer:first-child { padding-left: 0; }
- #pxnaolhmin .gt_column_spanner_outer:last-child { padding-right: 0; }
- #pxnaolhmin .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
- #pxnaolhmin .gt_spanner_row { border-bottom-style: hidden; }
- #pxnaolhmin .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
- #pxnaolhmin .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
- #pxnaolhmin .gt_from_md> :first-child { margin-top: 0; }
- #pxnaolhmin .gt_from_md> :last-child { margin-bottom: 0; }
- #pxnaolhmin .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
- #pxnaolhmin .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
- #pxnaolhmin .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
- #pxnaolhmin .gt_row_group_first td { border-top-width: 2px; }
- #pxnaolhmin .gt_row_group_first th { border-top-width: 2px; }
- #pxnaolhmin .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #pxnaolhmin .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
- #pxnaolhmin .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
- #pxnaolhmin .gt_left { text-align: left; }
- #pxnaolhmin .gt_center { text-align: center; }
- #pxnaolhmin .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
- #pxnaolhmin .gt_font_normal { font-weight: normal; }
- #pxnaolhmin .gt_font_bold { font-weight: bold; }
- #pxnaolhmin .gt_font_italic { font-style: italic; }
- #pxnaolhmin .gt_super { font-size: 65%; }
- #pxnaolhmin .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
- #pxnaolhmin .gt_asterisk { font-size: 100%; vertical-align: 0; }
+#bkcduztxsf p { margin: 0; padding: 0; }
+ #bkcduztxsf .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+ #bkcduztxsf .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+ #bkcduztxsf .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+ #bkcduztxsf .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
+ #bkcduztxsf .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #bkcduztxsf .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #bkcduztxsf .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #bkcduztxsf .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
+ #bkcduztxsf .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+ #bkcduztxsf .gt_column_spanner_outer:first-child { padding-left: 0; }
+ #bkcduztxsf .gt_column_spanner_outer:last-child { padding-right: 0; }
+ #bkcduztxsf .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
+ #bkcduztxsf .gt_spanner_row { border-bottom-style: hidden; }
+ #bkcduztxsf .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+ #bkcduztxsf .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+ #bkcduztxsf .gt_from_md> :first-child { margin-top: 0; }
+ #bkcduztxsf .gt_from_md> :last-child { margin-bottom: 0; }
+ #bkcduztxsf .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+ #bkcduztxsf .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
+ #bkcduztxsf .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
+ #bkcduztxsf .gt_row_group_first td { border-top-width: 2px; }
+ #bkcduztxsf .gt_row_group_first th { border-top-width: 2px; }
+ #bkcduztxsf .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #bkcduztxsf .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+ #bkcduztxsf .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
+ #bkcduztxsf .gt_left { text-align: left; }
+ #bkcduztxsf .gt_center { text-align: center; }
+ #bkcduztxsf .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+ #bkcduztxsf .gt_font_normal { font-weight: normal; }
+ #bkcduztxsf .gt_font_bold { font-weight: bold; }
+ #bkcduztxsf .gt_font_italic { font-style: italic; }
+ #bkcduztxsf .gt_super { font-size: 65%; }
+ #bkcduztxsf .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+ #bkcduztxsf .gt_asterisk { font-size: 100%; vertical-align: 0; }
  
 </style>
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
@@ -97,76 +97,88 @@
     <td class="gt_row gt_center">0.84</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_tfidf_1000_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.86</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.67</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.95</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.40</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.90</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.50</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_embeddings_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.93</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.75</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.72</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.74</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">3000</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.84</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.90</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">all_models_top3_features</td>
-    <td class="gt_row gt_center">0.91</td>
-    <td class="gt_row gt_center">0.44</td>
-    <td class="gt_row gt_center">0.78</td>
-    <td class="gt_row gt_center">0.69</td>
-    <td class="gt_row gt_center">0.84</td>
-    <td class="gt_row gt_center">0.53</td>
+    <td class="gt_row gt_left">all_models_tfidf_1000_features</td>
+    <td class="gt_row gt_center">0.86</td>
+    <td class="gt_row gt_center">0.67</td>
+    <td class="gt_row gt_center">0.95</td>
+    <td class="gt_row gt_center">0.40</td>
+    <td class="gt_row gt_center">0.90</td>
+    <td class="gt_row gt_center">0.50</td>
     <td class="gt_row gt_center">3000</td>
     <td class="gt_row gt_center">750</td>
-    <td class="gt_row gt_center">0.76</td>
+    <td class="gt_row gt_center">0.84</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">beluga7b-human_all_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.77</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.75</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.74</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.77</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.75</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_top3_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.91</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.44</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.78</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.69</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.84</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.53</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">3000</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.76</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.76</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">llama2_chat13b-human_all_features</td>
-    <td class="gt_row gt_center">0.88</td>
-    <td class="gt_row gt_center">0.85</td>
-    <td class="gt_row gt_center">0.85</td>
-    <td class="gt_row gt_center">0.89</td>
-    <td class="gt_row gt_center">0.87</td>
-    <td class="gt_row gt_center">0.87</td>
-    <td class="gt_row gt_center">750</td>
-    <td class="gt_row gt_center">750</td>
-    <td class="gt_row gt_center">0.87</td>
-  </tr>
-  <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat7b-human_all_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.89</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.86</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.85</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.90</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.88</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_left">mistral7b-human_all_features</td>
-    <td class="gt_row gt_center">0.76</td>
-    <td class="gt_row gt_center">0.79</td>
-    <td class="gt_row gt_center">0.80</td>
-    <td class="gt_row gt_center">0.75</td>
-    <td class="gt_row gt_center">0.78</td>
+    <td class="gt_row gt_left">beluga7b-human_all_features</td>
     <td class="gt_row gt_center">0.77</td>
+    <td class="gt_row gt_center">0.75</td>
+    <td class="gt_row gt_center">0.74</td>
+    <td class="gt_row gt_center">0.77</td>
+    <td class="gt_row gt_center">0.75</td>
+    <td class="gt_row gt_center">0.76</td>
     <td class="gt_row gt_center">750</td>
     <td class="gt_row gt_center">750</td>
-    <td class="gt_row gt_center">0.78</td>
+    <td class="gt_row gt_center">0.76</td>
+  </tr>
+  <tr>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat13b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.88</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.85</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.85</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.89</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_left">llama2_chat7b-human_all_features</td>
+    <td class="gt_row gt_center">0.89</td>
+    <td class="gt_row gt_center">0.86</td>
+    <td class="gt_row gt_center">0.85</td>
+    <td class="gt_row gt_center">0.90</td>
+    <td class="gt_row gt_center">0.87</td>
+    <td class="gt_row gt_center">0.88</td>
+    <td class="gt_row gt_center">750</td>
+    <td class="gt_row gt_center">750</td>
+    <td class="gt_row gt_center">0.87</td>
+  </tr>
+  <tr>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">mistral7b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.76</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.79</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.80</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.75</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.78</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.77</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.78</td>
   </tr>
 </tbody>
 

--- a/results/classify/clf_results/clf_reports/dailymail_cnn_temp1/all_models_embeddings_all_features.txt
+++ b/results/classify/clf_results/clf_reports/dailymail_cnn_temp1/all_models_embeddings_all_features.txt
@@ -1,0 +1,14 @@
+Results from model run at 2024-10-28 16:30:22.779668
+Original dataset: dailymail_cnn, temperature: nan
+Random state: 129
+              precision    recall  f1-score   support
+
+           0       0.97      0.98      0.98      1800
+           1       0.92      0.89      0.90       450
+
+    accuracy                           0.96      2250
+   macro avg       0.94      0.93      0.94      2250
+weighted avg       0.96      0.96      0.96      2250
+
+Model(s) compared with human:['beluga7b', 'llama2_chat13b', 'llama2_chat7b', 'mistral7b']
+Features: ['embeddings', 'dims: 4096']

--- a/results/classify/clf_results/clf_reports/dailymail_cnn_temp1/all_results.html
+++ b/results/classify/clf_results/clf_reports/dailymail_cnn_temp1/all_results.html
@@ -4,51 +4,51 @@
 <meta charset="utf-8"/>
 </head>
 <body>
-<div id="tyltnwqyli" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="ilycxnnfdg" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 <style>
-#tyltnwqyli table {
+#ilycxnnfdg table {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
 
-#tyltnwqyli thead, tbody, tfoot, tr, td, th { border-style: none; }
+#ilycxnnfdg thead, tbody, tfoot, tr, td, th { border-style: none; }
  tr { background-color: transparent; }
-#tyltnwqyli p { margin: 0; padding: 0; }
- #tyltnwqyli .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
- #tyltnwqyli .gt_caption { padding-top: 4px; padding-bottom: 4px; }
- #tyltnwqyli .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
- #tyltnwqyli .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
- #tyltnwqyli .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #tyltnwqyli .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #tyltnwqyli .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #tyltnwqyli .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
- #tyltnwqyli .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
- #tyltnwqyli .gt_column_spanner_outer:first-child { padding-left: 0; }
- #tyltnwqyli .gt_column_spanner_outer:last-child { padding-right: 0; }
- #tyltnwqyli .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
- #tyltnwqyli .gt_spanner_row { border-bottom-style: hidden; }
- #tyltnwqyli .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
- #tyltnwqyli .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
- #tyltnwqyli .gt_from_md> :first-child { margin-top: 0; }
- #tyltnwqyli .gt_from_md> :last-child { margin-bottom: 0; }
- #tyltnwqyli .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
- #tyltnwqyli .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
- #tyltnwqyli .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
- #tyltnwqyli .gt_row_group_first td { border-top-width: 2px; }
- #tyltnwqyli .gt_row_group_first th { border-top-width: 2px; }
- #tyltnwqyli .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #tyltnwqyli .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
- #tyltnwqyli .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
- #tyltnwqyli .gt_left { text-align: left; }
- #tyltnwqyli .gt_center { text-align: center; }
- #tyltnwqyli .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
- #tyltnwqyli .gt_font_normal { font-weight: normal; }
- #tyltnwqyli .gt_font_bold { font-weight: bold; }
- #tyltnwqyli .gt_font_italic { font-style: italic; }
- #tyltnwqyli .gt_super { font-size: 65%; }
- #tyltnwqyli .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
- #tyltnwqyli .gt_asterisk { font-size: 100%; vertical-align: 0; }
+#ilycxnnfdg p { margin: 0; padding: 0; }
+ #ilycxnnfdg .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+ #ilycxnnfdg .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+ #ilycxnnfdg .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+ #ilycxnnfdg .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
+ #ilycxnnfdg .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #ilycxnnfdg .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #ilycxnnfdg .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #ilycxnnfdg .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
+ #ilycxnnfdg .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+ #ilycxnnfdg .gt_column_spanner_outer:first-child { padding-left: 0; }
+ #ilycxnnfdg .gt_column_spanner_outer:last-child { padding-right: 0; }
+ #ilycxnnfdg .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
+ #ilycxnnfdg .gt_spanner_row { border-bottom-style: hidden; }
+ #ilycxnnfdg .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+ #ilycxnnfdg .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+ #ilycxnnfdg .gt_from_md> :first-child { margin-top: 0; }
+ #ilycxnnfdg .gt_from_md> :last-child { margin-bottom: 0; }
+ #ilycxnnfdg .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+ #ilycxnnfdg .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
+ #ilycxnnfdg .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
+ #ilycxnnfdg .gt_row_group_first td { border-top-width: 2px; }
+ #ilycxnnfdg .gt_row_group_first th { border-top-width: 2px; }
+ #ilycxnnfdg .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #ilycxnnfdg .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+ #ilycxnnfdg .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
+ #ilycxnnfdg .gt_left { text-align: left; }
+ #ilycxnnfdg .gt_center { text-align: center; }
+ #ilycxnnfdg .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+ #ilycxnnfdg .gt_font_normal { font-weight: normal; }
+ #ilycxnnfdg .gt_font_bold { font-weight: bold; }
+ #ilycxnnfdg .gt_font_italic { font-style: italic; }
+ #ilycxnnfdg .gt_super { font-size: 65%; }
+ #ilycxnnfdg .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+ #ilycxnnfdg .gt_asterisk { font-size: 100%; vertical-align: 0; }
  
 </style>
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
@@ -97,76 +97,88 @@
     <td class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_tfidf_1000_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.93</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.75</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.96</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.83</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_embeddings_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.92</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.89</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.90</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">1800</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">450</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.96</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">all_models_top3_features</td>
-    <td class="gt_row gt_center">0.97</td>
-    <td class="gt_row gt_center">0.89</td>
-    <td class="gt_row gt_center">0.97</td>
-    <td class="gt_row gt_center">0.87</td>
-    <td class="gt_row gt_center">0.97</td>
-    <td class="gt_row gt_center">0.88</td>
+    <td class="gt_row gt_left">all_models_tfidf_1000_features</td>
+    <td class="gt_row gt_center">0.94</td>
+    <td class="gt_row gt_center">0.93</td>
+    <td class="gt_row gt_center">0.99</td>
+    <td class="gt_row gt_center">0.75</td>
+    <td class="gt_row gt_center">0.96</td>
+    <td class="gt_row gt_center">0.83</td>
     <td class="gt_row gt_center">1800</td>
     <td class="gt_row gt_center">450</td>
-    <td class="gt_row gt_center">0.95</td>
+    <td class="gt_row gt_center">0.94</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">beluga7b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_top3_features</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.89</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.88</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">1800</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">450</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.95</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_left">beluga7b-human_all_features</td>
+    <td class="gt_row gt_center">0.97</td>
+    <td class="gt_row gt_center">1.00</td>
+    <td class="gt_row gt_center">1.00</td>
+    <td class="gt_row gt_center">0.97</td>
+    <td class="gt_row gt_center">0.98</td>
+    <td class="gt_row gt_center">0.98</td>
+    <td class="gt_row gt_center">450</td>
+    <td class="gt_row gt_center">450</td>
+    <td class="gt_row gt_center">0.98</td>
+  </tr>
+  <tr>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat13b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">1.00</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">1.00</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">450</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">450</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">llama2_chat13b-human_all_features</td>
-    <td class="gt_row gt_center">0.98</td>
-    <td class="gt_row gt_center">1.00</td>
-    <td class="gt_row gt_center">1.00</td>
+    <td class="gt_row gt_left">llama2_chat7b-human_all_features</td>
     <td class="gt_row gt_center">0.98</td>
     <td class="gt_row gt_center">0.99</td>
     <td class="gt_row gt_center">0.99</td>
+    <td class="gt_row gt_center">0.98</td>
+    <td class="gt_row gt_center">0.99</td>
+    <td class="gt_row gt_center">0.99</td>
     <td class="gt_row gt_center">450</td>
     <td class="gt_row gt_center">450</td>
     <td class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat7b-human_all_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">mistral7b-human_all_features</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">1.00</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">1.00</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">450</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">450</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_left">mistral7b-human_all_features</td>
-    <td class="gt_row gt_center">0.99</td>
-    <td class="gt_row gt_center">1.00</td>
-    <td class="gt_row gt_center">1.00</td>
-    <td class="gt_row gt_center">0.99</td>
-    <td class="gt_row gt_center">0.99</td>
-    <td class="gt_row gt_center">0.99</td>
-    <td class="gt_row gt_center">450</td>
-    <td class="gt_row gt_center">450</td>
-    <td class="gt_row gt_center">0.99</td>
   </tr>
 </tbody>
 

--- a/results/classify/clf_results/clf_reports/mrpc_temp1/all_models_embeddings_all_features.txt
+++ b/results/classify/clf_results/clf_reports/mrpc_temp1/all_models_embeddings_all_features.txt
@@ -1,0 +1,14 @@
+Results from model run at 2024-10-28 16:31:31.581059
+Original dataset: mrpc, temperature: nan
+Random state: 129
+              precision    recall  f1-score   support
+
+           0       0.91      0.92      0.92      2340
+           1       0.68      0.64      0.66       585
+
+    accuracy                           0.87      2925
+   macro avg       0.80      0.78      0.79      2925
+weighted avg       0.87      0.87      0.87      2925
+
+Model(s) compared with human:['beluga7b', 'llama2_chat13b', 'llama2_chat7b', 'mistral7b']
+Features: ['embeddings', 'dims: 4096']

--- a/results/classify/clf_results/clf_reports/mrpc_temp1/all_results.html
+++ b/results/classify/clf_results/clf_reports/mrpc_temp1/all_results.html
@@ -4,51 +4,51 @@
 <meta charset="utf-8"/>
 </head>
 <body>
-<div id="ckimzztrvr" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="acisbglgml" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 <style>
-#ckimzztrvr table {
+#acisbglgml table {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
 
-#ckimzztrvr thead, tbody, tfoot, tr, td, th { border-style: none; }
+#acisbglgml thead, tbody, tfoot, tr, td, th { border-style: none; }
  tr { background-color: transparent; }
-#ckimzztrvr p { margin: 0; padding: 0; }
- #ckimzztrvr .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
- #ckimzztrvr .gt_caption { padding-top: 4px; padding-bottom: 4px; }
- #ckimzztrvr .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
- #ckimzztrvr .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
- #ckimzztrvr .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #ckimzztrvr .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #ckimzztrvr .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #ckimzztrvr .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
- #ckimzztrvr .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
- #ckimzztrvr .gt_column_spanner_outer:first-child { padding-left: 0; }
- #ckimzztrvr .gt_column_spanner_outer:last-child { padding-right: 0; }
- #ckimzztrvr .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
- #ckimzztrvr .gt_spanner_row { border-bottom-style: hidden; }
- #ckimzztrvr .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
- #ckimzztrvr .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
- #ckimzztrvr .gt_from_md> :first-child { margin-top: 0; }
- #ckimzztrvr .gt_from_md> :last-child { margin-bottom: 0; }
- #ckimzztrvr .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
- #ckimzztrvr .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
- #ckimzztrvr .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
- #ckimzztrvr .gt_row_group_first td { border-top-width: 2px; }
- #ckimzztrvr .gt_row_group_first th { border-top-width: 2px; }
- #ckimzztrvr .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #ckimzztrvr .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
- #ckimzztrvr .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
- #ckimzztrvr .gt_left { text-align: left; }
- #ckimzztrvr .gt_center { text-align: center; }
- #ckimzztrvr .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
- #ckimzztrvr .gt_font_normal { font-weight: normal; }
- #ckimzztrvr .gt_font_bold { font-weight: bold; }
- #ckimzztrvr .gt_font_italic { font-style: italic; }
- #ckimzztrvr .gt_super { font-size: 65%; }
- #ckimzztrvr .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
- #ckimzztrvr .gt_asterisk { font-size: 100%; vertical-align: 0; }
+#acisbglgml p { margin: 0; padding: 0; }
+ #acisbglgml .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+ #acisbglgml .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+ #acisbglgml .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+ #acisbglgml .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
+ #acisbglgml .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #acisbglgml .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #acisbglgml .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #acisbglgml .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
+ #acisbglgml .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+ #acisbglgml .gt_column_spanner_outer:first-child { padding-left: 0; }
+ #acisbglgml .gt_column_spanner_outer:last-child { padding-right: 0; }
+ #acisbglgml .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
+ #acisbglgml .gt_spanner_row { border-bottom-style: hidden; }
+ #acisbglgml .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+ #acisbglgml .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+ #acisbglgml .gt_from_md> :first-child { margin-top: 0; }
+ #acisbglgml .gt_from_md> :last-child { margin-bottom: 0; }
+ #acisbglgml .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+ #acisbglgml .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
+ #acisbglgml .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
+ #acisbglgml .gt_row_group_first td { border-top-width: 2px; }
+ #acisbglgml .gt_row_group_first th { border-top-width: 2px; }
+ #acisbglgml .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #acisbglgml .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+ #acisbglgml .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
+ #acisbglgml .gt_left { text-align: left; }
+ #acisbglgml .gt_center { text-align: center; }
+ #acisbglgml .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+ #acisbglgml .gt_font_normal { font-weight: normal; }
+ #acisbglgml .gt_font_bold { font-weight: bold; }
+ #acisbglgml .gt_font_italic { font-style: italic; }
+ #acisbglgml .gt_super { font-size: 65%; }
+ #acisbglgml .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+ #acisbglgml .gt_asterisk { font-size: 100%; vertical-align: 0; }
  
 </style>
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
@@ -97,76 +97,88 @@
     <td class="gt_row gt_center">0.79</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_tfidf_1000_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.88</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.83</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.44</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_embeddings_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.91</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.68</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.92</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.58</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.64</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.92</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.66</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">2340</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.87</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">all_models_top3_features</td>
-    <td class="gt_row gt_center">0.90</td>
-    <td class="gt_row gt_center">0.39</td>
-    <td class="gt_row gt_center">0.74</td>
-    <td class="gt_row gt_center">0.67</td>
-    <td class="gt_row gt_center">0.81</td>
-    <td class="gt_row gt_center">0.49</td>
+    <td class="gt_row gt_left">all_models_tfidf_1000_features</td>
+    <td class="gt_row gt_center">0.88</td>
+    <td class="gt_row gt_center">0.83</td>
+    <td class="gt_row gt_center">0.98</td>
+    <td class="gt_row gt_center">0.44</td>
+    <td class="gt_row gt_center">0.92</td>
+    <td class="gt_row gt_center">0.58</td>
     <td class="gt_row gt_center">2340</td>
     <td class="gt_row gt_center">585</td>
-    <td class="gt_row gt_center">0.73</td>
+    <td class="gt_row gt_center">0.87</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">beluga7b-human_all_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.67</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.66</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.65</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.68</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.66</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.67</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.66</td>
-  </tr>
-  <tr>
-    <td class="gt_row gt_left">llama2_chat13b-human_all_features</td>
-    <td class="gt_row gt_center">0.93</td>
-    <td class="gt_row gt_center">0.88</td>
-    <td class="gt_row gt_center">0.88</td>
-    <td class="gt_row gt_center">0.94</td>
-    <td class="gt_row gt_center">0.90</td>
-    <td class="gt_row gt_center">0.91</td>
-    <td class="gt_row gt_center">585</td>
-    <td class="gt_row gt_center">585</td>
-    <td class="gt_row gt_center">0.91</td>
-  </tr>
-  <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat7b-human_all_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.77</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.70</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.79</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_top3_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.90</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.39</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.74</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.76</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.67</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.81</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.49</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">2340</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.75</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">mistral7b-human_all_features</td>
-    <td class="gt_row gt_center">0.73</td>
-    <td class="gt_row gt_center">0.73</td>
-    <td class="gt_row gt_center">0.73</td>
-    <td class="gt_row gt_center">0.73</td>
-    <td class="gt_row gt_center">0.73</td>
-    <td class="gt_row gt_center">0.73</td>
+    <td class="gt_row gt_left">beluga7b-human_all_features</td>
+    <td class="gt_row gt_center">0.67</td>
+    <td class="gt_row gt_center">0.66</td>
+    <td class="gt_row gt_center">0.65</td>
+    <td class="gt_row gt_center">0.68</td>
+    <td class="gt_row gt_center">0.66</td>
+    <td class="gt_row gt_center">0.67</td>
     <td class="gt_row gt_center">585</td>
     <td class="gt_row gt_center">585</td>
+    <td class="gt_row gt_center">0.66</td>
+  </tr>
+  <tr>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat13b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.93</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.88</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.88</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.90</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.91</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.91</td>
+  </tr>
+  <tr>
+    <td class="gt_row gt_left">llama2_chat7b-human_all_features</td>
+    <td class="gt_row gt_center">0.77</td>
     <td class="gt_row gt_center">0.73</td>
+    <td class="gt_row gt_center">0.70</td>
+    <td class="gt_row gt_center">0.79</td>
+    <td class="gt_row gt_center">0.74</td>
+    <td class="gt_row gt_center">0.76</td>
+    <td class="gt_row gt_center">585</td>
+    <td class="gt_row gt_center">585</td>
+    <td class="gt_row gt_center">0.75</td>
+  </tr>
+  <tr>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">mistral7b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">585</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.73</td>
   </tr>
 </tbody>
 

--- a/results/classify/clf_results/clf_reports/stories_temp1/all_models_embeddings_all_features.txt
+++ b/results/classify/clf_results/clf_reports/stories_temp1/all_models_embeddings_all_features.txt
@@ -1,0 +1,14 @@
+Results from model run at 2024-10-28 16:32:25.569492
+Original dataset: stories, temperature: nan
+Random state: 129
+              precision    recall  f1-score   support
+
+           0       0.99      0.99      0.99      3000
+           1       0.96      0.98      0.97       750
+
+    accuracy                           0.99      3750
+   macro avg       0.98      0.98      0.98      3750
+weighted avg       0.99      0.99      0.99      3750
+
+Model(s) compared with human:['beluga7b', 'llama2_chat13b', 'llama2_chat7b', 'mistral7b']
+Features: ['embeddings', 'dims: 4096']

--- a/results/classify/clf_results/clf_reports/stories_temp1/all_results.html
+++ b/results/classify/clf_results/clf_reports/stories_temp1/all_results.html
@@ -4,51 +4,51 @@
 <meta charset="utf-8"/>
 </head>
 <body>
-<div id="vusrqiynwj" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
+<div id="kecelfunaw" style="padding-left:0px;padding-right:0px;padding-top:10px;padding-bottom:10px;overflow-x:auto;overflow-y:auto;width:auto;height:auto;">
 <style>
-#vusrqiynwj table {
+#kecelfunaw table {
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', 'Fira Sans', 'Droid Sans', Arial, sans-serif;
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
 
-#vusrqiynwj thead, tbody, tfoot, tr, td, th { border-style: none; }
+#kecelfunaw thead, tbody, tfoot, tr, td, th { border-style: none; }
  tr { background-color: transparent; }
-#vusrqiynwj p { margin: 0; padding: 0; }
- #vusrqiynwj .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
- #vusrqiynwj .gt_caption { padding-top: 4px; padding-bottom: 4px; }
- #vusrqiynwj .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
- #vusrqiynwj .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
- #vusrqiynwj .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #vusrqiynwj .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #vusrqiynwj .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
- #vusrqiynwj .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
- #vusrqiynwj .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
- #vusrqiynwj .gt_column_spanner_outer:first-child { padding-left: 0; }
- #vusrqiynwj .gt_column_spanner_outer:last-child { padding-right: 0; }
- #vusrqiynwj .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
- #vusrqiynwj .gt_spanner_row { border-bottom-style: hidden; }
- #vusrqiynwj .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
- #vusrqiynwj .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
- #vusrqiynwj .gt_from_md> :first-child { margin-top: 0; }
- #vusrqiynwj .gt_from_md> :last-child { margin-bottom: 0; }
- #vusrqiynwj .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
- #vusrqiynwj .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
- #vusrqiynwj .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
- #vusrqiynwj .gt_row_group_first td { border-top-width: 2px; }
- #vusrqiynwj .gt_row_group_first th { border-top-width: 2px; }
- #vusrqiynwj .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
- #vusrqiynwj .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
- #vusrqiynwj .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
- #vusrqiynwj .gt_left { text-align: left; }
- #vusrqiynwj .gt_center { text-align: center; }
- #vusrqiynwj .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
- #vusrqiynwj .gt_font_normal { font-weight: normal; }
- #vusrqiynwj .gt_font_bold { font-weight: bold; }
- #vusrqiynwj .gt_font_italic { font-style: italic; }
- #vusrqiynwj .gt_super { font-size: 65%; }
- #vusrqiynwj .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
- #vusrqiynwj .gt_asterisk { font-size: 100%; vertical-align: 0; }
+#kecelfunaw p { margin: 0; padding: 0; }
+ #kecelfunaw .gt_table { display: table; border-collapse: collapse; line-height: normal; margin-left: auto; margin-right: auto; color: #333333; font-size: 16px; font-weight: normal; font-style: normal; background-color: #FFFFFF; width: auto; border-top-style: solid; border-top-width: 2px; border-top-color: #A8A8A8; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #A8A8A8; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; }
+ #kecelfunaw .gt_caption { padding-top: 4px; padding-bottom: 4px; }
+ #kecelfunaw .gt_title { color: #333333; font-size: 125%; font-weight: initial; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; border-bottom-color: #FFFFFF; border-bottom-width: 0; }
+ #kecelfunaw .gt_subtitle { color: #333333; font-size: 85%; font-weight: initial; padding-top: 7px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; border-top-color: #FFFFFF; border-top-width: 0; }
+ #kecelfunaw .gt_heading { background-color: #FFFFFF; text-align: center; border-bottom-color: #FFFFFF; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #kecelfunaw .gt_bottom_border { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #kecelfunaw .gt_col_headings { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; }
+ #kecelfunaw .gt_col_heading { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 9px; padding-left: 15px; padding-right: 15px; overflow-x: hidden; }
+ #kecelfunaw .gt_column_spanner_outer { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: normal; text-transform: inherit; padding-top: 0; padding-bottom: 0; padding-left: 4px; padding-right: 4px; }
+ #kecelfunaw .gt_column_spanner_outer:first-child { padding-left: 0; }
+ #kecelfunaw .gt_column_spanner_outer:last-child { padding-right: 0; }
+ #kecelfunaw .gt_column_spanner { border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: bottom; padding-top: 10px; padding-bottom: 10px; overflow-x: hidden; display: inline-block; width: 100%; }
+ #kecelfunaw .gt_spanner_row { border-bottom-style: hidden; }
+ #kecelfunaw .gt_group_heading { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; text-align: left; }
+ #kecelfunaw .gt_empty_group_heading { padding: 0.5px; color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; vertical-align: middle; }
+ #kecelfunaw .gt_from_md> :first-child { margin-top: 0; }
+ #kecelfunaw .gt_from_md> :last-child { margin-bottom: 0; }
+ #kecelfunaw .gt_row { padding-top: 16px; padding-bottom: 16px; padding-left: 15px; padding-right: 15px; margin: 10px; border-top-style: solid; border-top-width: 1px; border-top-color: #D3D3D3; border-left-style: none; border-left-width: 1px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 1px; border-right-color: #D3D3D3; vertical-align: middle; overflow-x: hidden; }
+ #kecelfunaw .gt_stub { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; }
+ #kecelfunaw .gt_stub_row_group { color: #333333; background-color: #FFFFFF; font-size: 100%; font-weight: initial; text-transform: inherit; border-right-style: solid; border-right-width: 2px; border-right-color: #D3D3D3; padding-left: 15px; padding-right: 15px; vertical-align: top; }
+ #kecelfunaw .gt_row_group_first td { border-top-width: 2px; }
+ #kecelfunaw .gt_row_group_first th { border-top-width: 2px; }
+ #kecelfunaw .gt_table_body { border-top-style: solid; border-top-width: 2px; border-top-color: #D3D3D3; border-bottom-style: solid; border-bottom-width: 2px; border-bottom-color: #D3D3D3; }
+ #kecelfunaw .gt_sourcenotes { color: #333333; background-color: #FFFFFF; border-bottom-style: none; border-bottom-width: 2px; border-bottom-color: #D3D3D3; border-left-style: none; border-left-width: 2px; border-left-color: #D3D3D3; border-right-style: none; border-right-width: 2px; border-right-color: #D3D3D3; }
+ #kecelfunaw .gt_sourcenote { font-size: 90%; padding-top: 8px; padding-bottom: 8px; padding-left: 15px; padding-right: 15px; text-align: left; }
+ #kecelfunaw .gt_left { text-align: left; }
+ #kecelfunaw .gt_center { text-align: center; }
+ #kecelfunaw .gt_right { text-align: right; font-variant-numeric: tabular-nums; }
+ #kecelfunaw .gt_font_normal { font-weight: normal; }
+ #kecelfunaw .gt_font_bold { font-weight: bold; }
+ #kecelfunaw .gt_font_italic { font-style: italic; }
+ #kecelfunaw .gt_super { font-size: 65%; }
+ #kecelfunaw .gt_footnote_marks { font-size: 75%; vertical-align: 0.4em; position: initial; }
+ #kecelfunaw .gt_asterisk { font-size: 100%; vertical-align: 0; }
  
 </style>
 <table class="gt_table" data-quarto-disable-processing="false" data-quarto-bootstrap="false">
@@ -97,43 +97,43 @@
     <td class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_tfidf_1000_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_embeddings_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.96</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.93</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">3000</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.98</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">all_models_top3_features</td>
-    <td class="gt_row gt_center">0.97</td>
-    <td class="gt_row gt_center">0.81</td>
-    <td class="gt_row gt_center">0.95</td>
-    <td class="gt_row gt_center">0.89</td>
+    <td class="gt_row gt_left">all_models_tfidf_1000_features</td>
+    <td class="gt_row gt_center">0.98</td>
     <td class="gt_row gt_center">0.96</td>
-    <td class="gt_row gt_center">0.85</td>
+    <td class="gt_row gt_center">0.99</td>
+    <td class="gt_row gt_center">0.93</td>
+    <td class="gt_row gt_center">0.99</td>
+    <td class="gt_row gt_center">0.94</td>
     <td class="gt_row gt_center">3000</td>
     <td class="gt_row gt_center">750</td>
-    <td class="gt_row gt_center">0.94</td>
+    <td class="gt_row gt_center">0.98</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">beluga7b-human_all_features</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">all_models_top3_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.97</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.81</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.95</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.89</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.96</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.85</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">3000</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
-    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.94</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">llama2_chat13b-human_all_features</td>
+    <td class="gt_row gt_left">beluga7b-human_all_features</td>
     <td class="gt_row gt_center">0.99</td>
     <td class="gt_row gt_center">0.99</td>
     <td class="gt_row gt_center">0.99</td>
@@ -145,7 +145,7 @@
     <td class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat7b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">llama2_chat13b-human_all_features</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
@@ -157,7 +157,7 @@
     <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
   </tr>
   <tr>
-    <td class="gt_row gt_left">mistral7b-human_all_features</td>
+    <td class="gt_row gt_left">llama2_chat7b-human_all_features</td>
     <td class="gt_row gt_center">0.99</td>
     <td class="gt_row gt_center">0.99</td>
     <td class="gt_row gt_center">0.99</td>
@@ -167,6 +167,18 @@
     <td class="gt_row gt_center">750</td>
     <td class="gt_row gt_center">750</td>
     <td class="gt_row gt_center">0.99</td>
+  </tr>
+  <tr>
+    <td style="background-color: lightgrey;" class="gt_row gt_left">mistral7b-human_all_features</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">750</td>
+    <td style="background-color: lightgrey;" class="gt_row gt_center">0.99</td>
   </tr>
 </tbody>
 

--- a/src/classify/run.sh
+++ b/src/classify/run.sh
@@ -41,6 +41,15 @@ do
     done
 done
 
+echo "[INFO:] Running classification with Embeddings"
+for dataset in "${datasets[@]}"
+do
+    for temp in "${temperatures[@]}"
+    do  
+        python run_clf_embeddings.py --dataset "$dataset" --temp "$temp"
+    done
+done
+
 echo "[INFO:] Making CLF table for all each dataset"
 for dataset in "${datasets[@]}"
 do

--- a/src/classify/run_clf_embeddings.py
+++ b/src/classify/run_clf_embeddings.py
@@ -1,0 +1,106 @@
+"""
+BASELINE: EMBEDDINGS + XGBOOST
+Run XGBOOST classifier for each dataset and temp combination on embeddings, save results to /results/classify/clf_results on all features.
+"""
+
+import argparse
+import pathlib
+import sys
+
+import pandas as pd
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+sys.path.append(str(pathlib.Path(__file__).parents[2]))
+from xgboost import XGBClassifier
+from src.utils.classify import clf_pipeline
+
+
+def input_parse():
+    parser = argparse.ArgumentParser()
+
+    # add dataset as arg
+    parser.add_argument(
+        "-d",
+        "--dataset",
+        default="dailymail_cnn",
+        help="Choose between 'stories', 'dailymail_cnn', 'mrpc', 'dailydialog'",
+        type=str,
+    )
+    parser.add_argument(
+        "-t", "--temp", default=1, help="Temperature of generations", type=float
+    )
+
+    args = parser.parse_args()
+
+    return args
+
+def main():
+    args = input_parse()
+    path = pathlib.Path(__file__)
+
+    dataset, temp = args.dataset, args.temp
+
+    if temp == 1.0:
+        temp = int(temp)
+
+    # load metrics
+    savepath = path.parents[2] / "results" / "classify" / "clf_results"
+    savepath.mkdir(parents=True, exist_ok=True)
+
+    datapath = path.parents[2] / "datasets_complete" / "text" / f"temp_{temp}"
+    embeddingspath = path.parents[2] / "datasets_complete" / "embeddings" / f"temp_{temp}"
+
+    ## a little bit of transformation back and forth, but necessary to be able to filter embeddings by dataset
+    # read embeddings (.npy file)
+    train_embeddings = np.load(embeddingspath / f"train_embeddings.npy")
+    val_embeddings = np.load(embeddingspath / f"val_embeddings.npy")
+
+    # read text data
+    train_df = pd.read_parquet(datapath / f"train_text.parquet")
+    val_df = pd.read_parquet(datapath / f"val_text.parquet")
+
+    # add embeddings to dataframes
+    train_df["embeddings"] = train_embeddings.tolist()
+    val_df["embeddings"] = val_embeddings.tolist()
+
+    # filter only to include one dataset
+    train_df = train_df[train_df["dataset"] == dataset]
+    val_df = val_df[val_df["dataset"] == dataset]
+
+    # get correct format for XGBoost
+    X_train_emb = np.array(train_df["embeddings"].tolist())
+    X_val_emb = np.array(val_df["embeddings"].tolist())
+
+    y_train = train_df["is_human"].values
+    y_val = val_df["is_human"].values
+
+    # compute scale_pos_weight
+    human_count = train_df[train_df["model"] == "human"].shape[0]
+    non_human_count = train_df[train_df["model"] != "human"].shape[0]
+    scale_pos_weight = non_human_count / human_count
+
+    clf = XGBClassifier(
+        enable_categorical=True,
+        use_label_encoder=False,
+        random_state=129,
+        scale_pos_weight=scale_pos_weight,
+    )
+
+    # fit
+    feature_names = ["embeddings", f"dims: {X_train_emb.shape[1]}"]
+    clf, clf_report = clf_pipeline(
+        df=train_df,
+        clf=clf,
+        X_train=X_train_emb,
+        y_train=y_train,
+        X_val=X_val_emb,
+        y_val=y_val,
+        feature_names=feature_names,
+        random_state=129,
+        save_dir=savepath / "clf_reports" / f"{dataset}_temp{temp}",
+        save_filename=f"all_models_embeddings_all_features",
+    )
+
+if __name__ == "__main__":
+    main()

--- a/src/make_dataset/embeddings_dataset.py
+++ b/src/make_dataset/embeddings_dataset.py
@@ -62,7 +62,7 @@ def main():
         
         # read data, extract sents
         df = pd.read_parquet(in_file)
-        sents = df["completions"].values
+        sents = df["completions"].tolist()
 
         # encode
         model = SentenceTransformer(
@@ -76,15 +76,19 @@ def main():
             batch_size=args.batch_size,
             show_progress_bar=True,
         )
+
+
         # save embeddings
-        out_path = (
-            pathlib.Path(args.out_path)
-            if args.out_path is not None
-            else default_paths["out_path"]
+        out_file = (
+            pathlib.Path(args.out_file)
+            if args.out_file is not None
+            else default_paths["out_file"]
         )
 
-        out_path.parents[1].mkdir(parents=True, exist_ok=True)
-        np.save(out_path, embeddings)
+        # create directory 
+        out_file.parents[0].mkdir(parents=True, exist_ok=True)
 
+        np.save(out_file, embeddings)
+    
 if __name__ == "__main__":
     main()

--- a/src/make_dataset/embeddings_dataset.py
+++ b/src/make_dataset/embeddings_dataset.py
@@ -19,7 +19,7 @@ def input_parse():
         "--batch_size",
         type=int,
         help="Batch size for encoding",
-        default=32,
+        default=16,
     )
 
     parser.add_argument(
@@ -53,6 +53,9 @@ def main():
         trust_remote_code=True,
         cache_folder=cache_models_path,
     )
+
+    # switch to FP16 (as FP32 caused memory issues) - see https://github.com/UKPLab/sentence-transformers/issues/822 
+    model.half()
 
     # load and process splits
     for split in splits:

--- a/src/make_dataset/embeddings_dataset.py
+++ b/src/make_dataset/embeddings_dataset.py
@@ -38,7 +38,16 @@ def main():
     
     splits = ["train", "val", "test"]
 
+    # load model 
+    model = SentenceTransformer(
+        model_name_or_path="nvidia/NV-Embed-v2",
+        trust_remote_code=True,
+        cache_folder=cache_models_path,
+        )
+
+    # load and process splits
     for split in splits: 
+        print(f"[INFO:] Embedding text from {split} split")
         default_paths = {
             "in_file": path.parents[2]
             / "datasets_complete"
@@ -64,19 +73,11 @@ def main():
         df = pd.read_parquet(in_file)
         sents = df["completions"].tolist()
 
-        # encode
-        model = SentenceTransformer(
-            model_name_or_path="nvidia/NV-Embed-v2",
-            trust_remote_code=True,
-            cache_folder=cache_models_path,
-        )
-
         embeddings = model.encode(
             sentences=sents,
             batch_size=args.batch_size,
             show_progress_bar=True,
         )
-
 
         # save embeddings
         out_file = (

--- a/src/make_dataset/embeddings_dataset.py
+++ b/src/make_dataset/embeddings_dataset.py
@@ -49,7 +49,7 @@ def main():
 
     # load model
     model = SentenceTransformer(
-        model_name_or_path="nvidia/NV-Embed-v2",
+        model_name_or_path="nvidia/NV-Embed-v2", # as of 2024-28-10, the best model on MTEB (classification)
         trust_remote_code=True,
         cache_folder=cache_models_path,
     )

--- a/src/make_dataset/embeddings_dataset.py
+++ b/src/make_dataset/embeddings_dataset.py
@@ -1,0 +1,90 @@
+"""
+Run embeddings on data parquet file and save the embeddings in a numpy file: 
+
+python src/create_embeddings.py --in_file /path/to/data.parquet --out_file /path/to/embeddings.npy
+"""
+
+import argparse
+import json
+import pathlib
+
+import pandas as pd
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+
+def input_parse():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        help="Batch size for encoding",
+        default=32,
+    )
+
+    parser.add_argument("--in_file", type=str, help="Path to file with data to encode")
+    parser.add_argument("--out_file", type=str, help="Path to save the embeddings")
+
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    temp = 1 
+
+    args = input_parse()
+    path = pathlib.Path(__file__)
+    cache_models_path = path.parents[3] / "models"
+    
+    splits = ["train", "val", "test"]
+
+    for split in splits: 
+        default_paths = {
+            "in_file": path.parents[2]
+            / "datasets_complete"
+            / "text"
+            / f"temp_{temp}"
+            / f"{split}_text.parquet",
+
+            "out_file": path.parents[2]
+            / "datasets_complete"
+            / "embeddings"
+            / f"temp_{temp}"
+            / f"{split}_embeddings.npy",
+        }
+
+        # grab data from default path if not provided
+        in_file = (
+            pathlib.Path(args.in_file)
+            if args.in_file is not None
+            else default_paths["in_file"]
+        )
+        
+        # read data, extract sents
+        df = pd.read_parquet(in_file)
+        sents = df["completions"].values
+
+        # encode
+        model = SentenceTransformer(
+            model_name_or_path="nvidia/NV-Embed-v2",
+            trust_remote_code=True,
+            cache_folder=cache_models_path,
+        )
+
+        embeddings = model.encode(
+            sentences=sents,
+            batch_size=args.batch_size,
+            show_progress_bar=True,
+        )
+        # save embeddings
+        out_path = (
+            pathlib.Path(args.out_path)
+            if args.out_path is not None
+            else default_paths["out_path"]
+        )
+
+        out_path.parents[1].mkdir(parents=True, exist_ok=True)
+        np.save(out_path, embeddings)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Embeddings
Embedded train, val and test completions using SentenceTransformers for one of our baselines (#75). Results are up and can be seen on the current classify readme on this branch (will be live on main branch after mergin). 

I had some model considerations for the choice of encoder - maybe you would like to comment on this before I merge, @rbroc ? 

### Model Considerations
The model [nvidia/NV-Embed-v2](https://huggingface.co/nvidia/NV-Embed-v2) was chosen for embedding the data as it was the highest ranked on [MTEB](https://huggingface.co/spaces/mteb/leaderboard) for classification, but might have been a little overkill (the model is 7.85B). I just thought it might be easiest to justify/defend in a paper. 

It did give some memory issues initially, but converting to FP16 (lower precision than FP32) and running with a relatively small batch size (16) was fine and took under 2 hours for all 84K ish rows on a single Nvidia L40 GPU (AAU). 